### PR TITLE
Probably working version of multi-platform extension with Windows, WSL and Wine support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,6 @@ jobs:
       - run: npm version
       - run: npm ci
       - run: npm install
-      - run: npm run lint || true
+      - run: npm run lint
       - run: npm test || true
       - run: npm run package

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,8 +4,22 @@ import tseslint from "typescript-eslint";
 
 
 export default [
-  {files: ["**/*.{js,mjs,cjs,ts}"]},
-  {languageOptions: { globals: globals.browser }},
+  {
+    files: ["**/*.{js,mjs,cjs,ts}"],
+  },
+  {
+    languageOptions: {
+      globals: {
+        ...globals.es2020,
+        ...globals.node,
+      },
+    },
+  },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-var-requires': 'off',
+    },
+  }
 ];

--- a/package.json
+++ b/package.json
@@ -37,20 +37,40 @@
           "default": "",
           "description": "%mql_compiler.configuration.MetaEditor4Path.description%"
         },
+        "mql_compiler.MTE.MetaEditor4PathIsWinePath": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mql_compiler.configuration.MetaEditor4PathIsWinePath.description%"
+        },
         "mql_compiler.MTE.IncludePath4": {
           "type": "string",
           "default": "",
           "description": "%mql_compiler.configuration.IncludePath4.description%"
+        },
+        "mql_compiler.MTE.IncludePath4IsWinePath": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mql_compiler.configuration.IncludePath4IsWinePath.description%"
         },
         "mql_compiler.MTE.MetaEditor5Path": {
           "type": "string",
           "default": "",
           "description": "%mql_compiler.configuration.MetaEditor5Path.description%"
         },
+        "mql_compiler.MTE.MetaEditor5PathIsWinePath": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mql_compiler.configuration.MetaEditor5PathIsWinePath.description%"
+        },
         "mql_compiler.MTE.IncludePath5": {
           "type": "string",
           "default": "",
           "description": "%mql_compiler.configuration.IncludePath5.description%"
+        },
+        "mql_compiler.MTE.IncludePath5IsWinePath": {
+          "type": "boolean",
+          "default": false,
+          "description": "%mql_compiler.configuration.IncludePath5IsWinePath.description%"
         },
         "mql_compiler.MTE.RemoveLog": {
           "type": "boolean",

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,9 +2,13 @@
   "mql_compiler.commands.checkSyntax.title": "Check syntax",
   "mql_compiler.commands.compileFile.title": "Compile file",
   "mql_compiler.configuration.IncludePath4.description": "(optional) Path to MetaEditor 4 include directory",
+  "mql_compiler.configuration.IncludePath4IsWinePath.description": "Whether path to MetaEditor 4 include directory is a Wine path",
   "mql_compiler.configuration.IncludePath5.description": "(optional) Path to MetaEditor 5 include directory",
+  "mql_compiler.configuration.IncludePath5IsWinePath.description": "Whether path to MetaEditor 5 include directory is a Wine path",
   "mql_compiler.configuration.MetaEditor4Path.description": "Path to MetaEditor 4 (e.g. /Path/MT4/metaeditor.exe)",
+  "mql_compiler.configuration.MetaEditor4PathIsWinePath.description": "Whether path to MetaEditor 4 is a Wine path",
   "mql_compiler.configuration.MetaEditor5Path.description": "Path to MetaEditor 5 (e.g. /Path/MT5/metaeditor64.exe)",
+  "mql_compiler.configuration.MetaEditor5PathIsWinePath.description": "Whether path to MetaEditor 4 is a Wine path",
   "mql_compiler.configuration.RemoveLog.description": "Remove log file after check/compile action.",
-  "mql_compiler.configuration.PassThroughWSL.description": "Pass command through WSL (only for Windows platform)."
+  "mql_compiler.configuration.PassThroughWSL.description": "Pass command through WSL on Windows or use WSL backend when running VS Code on WSL's Ubuntu."
 }

--- a/src/config.js
+++ b/src/config.js
@@ -25,6 +25,22 @@ function platformExecutablePath(platformVersion) {
 }
 
 /**
+ * Retrieves Is-Wine-Path for compiler's path for the given platform version.
+ * @param {number} platformVersion Version of the platform, e.g., 4 or 5.
+ */
+function platformExecutablePathIsWinePath(platformVersion) {
+  const config = get();
+  switch (platformVersion) {
+    case 4:
+      return config.MTE.MetaEditor4PathIsWinePath;
+    case 5:
+      return config.MTE.MetaEditor5PathIsWinePath;
+    default:
+      throw new Error(`Error: Unsupported platform version ${platformVersion}!`);
+  }
+}
+
+/**
  * Retrieves compiler's include path for the given platform version.
  * @param {number} platformVersion Version of the platform, e.g., 4 or 5.
  */
@@ -40,9 +56,27 @@ function platformIncludePath(platformVersion) {
   }
 }
 
+/**
+ * Retrieves Is-Wine-Path for compiler's include path for the given platform version.
+ * @param {number} platformVersion Version of the platform, e.g., 4 or 5.
+ */
+function platformIncludePathIsWinePath(platformVersion) {
+  const config = get();
+  switch (platformVersion) {
+    case 4:
+      return config.MTE.IncludePath4IsWinePath;
+    case 5:
+      return config.MTE.IncludePath5IsWinePath;
+    default:
+      throw new Error(`Error: Unsupported platform version ${platformVersion}!`);
+  }
+}
+
 module.exports = {
   get,
   get current() { return get(); },
   platformExecutablePath,
-  platformIncludePath
+  platformExecutablePathIsWinePath,
+  platformIncludePath,
+  platformIncludePathIsWinePath,
 };

--- a/src/debug.js
+++ b/src/debug.js
@@ -5,7 +5,7 @@ module.exports = {
   forceEnable: false,
 
   // Whether we want to override extension settings to the ones in "configOverride".
-  overrideConfig: true,
+  overrideConfig: false,
 
   // Whether we want to enable debug logging.
   get enabled() { return this.extensionDebugModeEnabled || this.forceEnable; },
@@ -16,8 +16,13 @@ module.exports = {
   // Debug configuration. Used when "configOverrideEnabled" is true.
   configOverride: {
     MTE: {
-      MetaEditor5Path: "c:/Program Files/MetaTrader 5/MetaEditor64.exe",
-      IncludePath5: "c:/Users/MX/AppData/Roaming/MetaQuotes/Terminal/D0E8209F77C8CF37AD8BF550E51FF075/MQL5/Include",
+      MetaEditor5Path: "C:/Program Files/MetaTrader 5/MetaEditor64.exe",
+      MetaEditor5PathIsWinePath: true,
+      //MetaEditor5Path: "/home/mx/.wine/dosdevices/c:/Program Files/MetaTrader 5/MetaEditor64.exe",
+      IncludePath5: "C:\\Users\\MX\\AppData\\Roaming\\MetaQuotes\\Terminal\\D0E8209F77C8CF37AD8BF550E51FF075\\MQL5\\Include",
+      IncludePath5IsWinePath: false,
+      //IncludePath5: "/home/mx/.wine/dosdevices/c:/Program Files/MetaTrader 5/MQL5/Include",
+      //IncludePath5: "",
       RemoveLog: false,
       PassThroughWSL: false
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
 // Extension life-cycle functions.
 const { activate, deactivate } = require('./lifecycle');
+const { runTests } = require('./tests');
 
 module.exports = {
   activate,
   deactivate
 }
+
+runTests();

--- a/src/log.js
+++ b/src/log.js
@@ -1,7 +1,7 @@
 const url = require('url');
 
 function replaceLog(str, f) {
-  let text = f ? '' : '\n\n', obj_hover = {}, ye;
+  let text = f ? '' : '\n\n', obj_hover = {};
   str.replace(/\u{FEFF}/gu, '').split('\n').forEach(item => {
     if (item.includes(f ? ': information: compiling' : ': information: checking')) {
       let regEx = new RegExp(`(?<=${f ? 'compiling' : 'checking'}.).+'`, 'gi'),
@@ -28,13 +28,10 @@ function replaceLog(str, f) {
 
       if (Err != null) {
         text += f ? '[Error] ' + item : '[Error] Result: ' + item.match(/\d+.error.+/);
-        ye = true;
       } else if (War != null) {
         text += f ? '[Warning] ' + item : '[Warning] Result: ' + item.match(/\d+.error.+/);
-        ye = false;
       } else {
         text += f ? '[Done] ' + item : '[Done] Result: ' + item.match(/\d+.error.+/);
-        ye = false;
       }
     }
     else {
@@ -46,7 +43,7 @@ function replaceLog(str, f) {
       name_res = name_res.replace(gh, '');
 
       if (link_res.match(/[a-z]:\\.+/gi) && name_res != '') {
-        Object.assign(obj_hover, { [name_res + ' ' + String(link_res.match(/\((?:\d+\,\d+)\)$/gm))]: { ['link']: String(url.pathToFileURL(link_res).href.replace(/\((?=(\d+,\d+).$)/gm, '#').replace(/\)$/gm, '')), ['number']: String(gh) } });
+        Object.assign(obj_hover, { [name_res + ' ' + String(link_res.match(/\((?:\d+,\d+)\)$/gm))]: { ['link']: String(url.pathToFileURL(link_res).href.replace(/\((?=(\d+,\d+).$)/gm, '#').replace(/\)$/gm, '')), ['number']: String(gh) } });
         text += name_res + ' ' + link_res.match(/(.)(?:\d+,\d+).$/gm) + '\n';
       }
       else {

--- a/src/mtlog.js
+++ b/src/mtlog.js
@@ -1,8 +1,4 @@
 const vscode = require('vscode');
-const output = require('./output');
-const includes = require('./includes');
-const workspace = require('./workspace');
-const wine = require('./wine');
 const { UniversalPath } = require('./universalpath');
 
 const reFileNameOnly = /^DISABLEDX$/i;
@@ -12,12 +8,9 @@ const reErrorOrWarning = /(^.*?)\((\d+),(\d+)\) : (error|warning) \d+: (.*?)$/;
  * Parses log and builds information about warning, errors and other important information.
  * @param {string} content
  */
-async function parse(content, platformVersion) {
+async function parse(content/*, platformVersion*/) {
   // Firstly, we split content into lines. We will be checking one line at a time.
-  lines = content.split(/\r?\n|\r/);
-
-  // File that previously occured in the log.
-  let currentFile = '';
+  const lines = content.split(/\r?\n|\r/);
 
   const result = {
     diagnostics: {}
@@ -27,7 +20,6 @@ async function parse(content, platformVersion) {
     const isFileNameOnly = reFileNameOnly.exec(line);
 
     if (isFileNameOnly) {
-      currentFile = isFileNameOnly[1];
       continue;
     }
 

--- a/src/tests.js
+++ b/src/tests.js
@@ -1,0 +1,159 @@
+const assert = require('node:assert/strict');
+
+const { OsType, UniversalPath } = require("./universalpath");
+
+class Tests {
+    constructor() {
+        // We're on Windows and we have Windows path. We don't use WSL.
+        this.pathWindowsHostWindowsPathDisabledWSL = new UniversalPath("C:\\devel\\test.mq5", false, undefined, OsType.Windows, false);
+
+        // We're on Windows and we have Windows path. WSL mode is enabled.
+        this.pathWindowsHostWindowsPathEnabledWSL = new UniversalPath("C:\\devel\\test.mq5", false, undefined, OsType.Windows, true);
+
+        // We're on Windows and we have Unix path. We don't use WSL.
+        this.pathWindowsHostUnixPathUnderWindowsDisabledWSL = new UniversalPath("/mnt/c/devel/test.mq5", false, undefined, OsType.Windows, false);
+
+        // We're on Windows and we have Unix path. WSL mode is enabled.
+        this.pathWindowsHostUnixPathUnderWindowsEnabledWSL = new UniversalPath("/mnt/c/devel/test.mq5", false, undefined, OsType.Windows, true);
+
+        // We're on Windows and we have inside-Wine path. We don't use WSL.
+        this.pathWindowsHostUnixPathUnderWineDisabledWSL = new UniversalPath("/home/USER/.wine/dosdevices/c:/devel/test.mq5", false, undefined, OsType.Windows, false);
+
+        // We're on Windows and we have inside-Wine path. WSL mode is enabled.
+        this.pathWindowsHostUnixPathUnderWineEnabledWSL = new UniversalPath("/home/USER/.wine/dosdevices/c:/devel/test.mq5", false, undefined, OsType.Windows, true);
+
+        // We're under WSL's Ubuntu and we have Windows' host path.
+        this.pathWslWindowsPathInsideWindows = new UniversalPath("C:\\devel\\test.mq5", false, undefined, OsType.Unix, true);
+
+        // We're under WSL's Ubuntu and we have inside-Wine path.
+        this.pathWslWindowsPathInsideWine = new UniversalPath("C:\\devel\\test.mq5", true, undefined, OsType.Unix, true);
+
+        // We're on Unix (outside WSL) and we have Unix-host path.
+        this.pathUnixHostUnixPath = new UniversalPath("/home/devel/test.mq5", false, undefined, OsType.Unix, undefined);
+
+        // We're on Unix (outside WSL) and we have inside-Wine path.
+        this.pathUnixHostUnixPathInsideWine = new UniversalPath("C:\\devel\\test.mq5", true, undefined, OsType.Unix, undefined);
+
+        // We're on Unix (outside WSL) and we have Windows path not marked as Wine path [Wrong].
+        this.pathUnixHostWindowsPathOutsideWine = new UniversalPath("C:\\devel\\test.mq5", false, undefined, OsType.Unix, undefined);
+    }
+
+    runAll() {
+        this.pathTest();
+    }
+
+    /**
+     * Executes UniversalPath and path.js functions' tests in order to check path conversion consistency.
+     */
+    pathTest() {
+        console.log(this);
+
+        // C:\\devel\\test.mq5 [Windows, Windows-style Path, Outside Wine, Non-WSL].
+        assert.strictEqual(this.pathWindowsHostWindowsPathDisabledWSL.isValid(), true);
+        assert.strictEqual(this.pathWindowsHostWindowsPathDisabledWSL.isHostWindows, true);
+        assert.strictEqual(this.pathWindowsHostWindowsPathDisabledWSL.isWinePath, false);
+        assert.strictEqual(this.pathWindowsHostWindowsPathDisabledWSL.isWslMode, false);
+        assert.strictEqual(this.pathWindowsHostWindowsPathDisabledWSL.asCliPath(), "C:\\devel\\test.mq5");
+        assert.strictEqual(this.pathWindowsHostWindowsPathDisabledWSL.asTargetPath(), "C:\\devel\\test.mq5");
+
+        // C:\\devel\\test.mq5 [Windows, Windows-style Path, Outside Wine, Through WSL].
+        assert.strictEqual(this.pathWindowsHostWindowsPathEnabledWSL.isValid(), true);
+        assert.strictEqual(this.pathWindowsHostWindowsPathEnabledWSL.isHostWindows, true);
+        assert.strictEqual(this.pathWindowsHostWindowsPathEnabledWSL.isWinePath, false);
+        assert.strictEqual(this.pathWindowsHostWindowsPathEnabledWSL.isWslMode, true);
+        assert.strictEqual(this.pathWindowsHostWindowsPathEnabledWSL.asCliPath(), "Z:\\mnt\\c\\devel\\test.mq5");
+        assert.strictEqual(this.pathWindowsHostWindowsPathEnabledWSL.asTargetPath(), "C:\\devel\\test.mq5");
+
+        // /mnt/c/devel/test.mq5 [Windows, Unix-style Path, Outside Wine, Non-WSL].
+        // Normally, we can't specify Unix path under Windows with disabled WSL mode.
+        // However, we allow such path, so user could leave it when switching between Windows and WSL if he expects Windows-host path.
+        // Such path will be converted to C:\devel\test.mq5 for metatrader.exe CLI usage (asCliPath) and for Windows-host read/write purposes (asTargetPath).
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWindowsDisabledWSL.isValid(), true);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWindowsDisabledWSL.isHostWindows, true);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWindowsDisabledWSL.isWinePath, false);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWindowsDisabledWSL.isWslMode, false);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWindowsDisabledWSL.asCliPath(), "C:\\devel\\test.mq5");
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWindowsDisabledWSL.asTargetPath(), "C:\\devel\\test.mq5");
+
+        // /mnt/c/devel/test.mq5 [Windows, Unix-style Path, Outside Wine, Through WSL].
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWindowsEnabledWSL.isValid(), true);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWindowsEnabledWSL.isHostWindows, true);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWindowsEnabledWSL.isWinePath, false);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWindowsEnabledWSL.isWslMode, true);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWindowsEnabledWSL.asCliPath(), "Z:\\mnt\\c\\devel\\test.mq5");
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWindowsEnabledWSL.asTargetPath(), "/mnt/c/devel/test.mq5");
+
+        // /home/USER/.wine/dosdevices/c:/devel/test.mq5 [Windows, Unix-style Path, Outside Wine, At Wine Folder, Non-WSL].
+        // This path is invalid. We can't map under-Wine path into path in non-WSL mode on Windows host.
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWineDisabledWSL.isValid(), false);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWineDisabledWSL.isHostWindows, true);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWineDisabledWSL.isWinePath, false);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWineDisabledWSL.isWslMode, false);
+
+        // /home/USER/.wine/dosdevices/c:/devel/test.mq5 [Windows, Unix-style Path, Outside Wine, At Wine Folder, Through WSL].
+        // Path will be mapped to inside-Wine path for cliPath() and under Wine on Windows-host for asTargetPath().
+        // @fixit Note that WSL machine name could be different than "Ubuntu". We need to detect it.
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWineEnabledWSL.isValid(), true);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWineEnabledWSL.isHostWindows, true);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWineEnabledWSL.isWinePath, false);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWineEnabledWSL.isWslMode, true);
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWineEnabledWSL.asCliPath(), "C:\\devel\\test.mq5");
+        assert.strictEqual(this.pathWindowsHostUnixPathUnderWineEnabledWSL.asTargetPath(), "\\\\wsl$\\Ubuntu\\home\\USER\\.wine\\dosdevices\\c:\\devel\\test.mq5");
+
+        // C:\\devel\\test.mq5 [WSL(Unix), Windows-style Path, Inside Windows, Through-WSL].
+        // Note that we can use Windows path only in Windows-host or WSL mode (WSL mode will be auto-detected).
+        // Thus, on Unix, switching on WSL mode will make the path invalid. Marking path as inside-Wine would help with that.
+        assert.strictEqual(this.pathWslWindowsPathInsideWindows.isValid(), true);
+        assert.strictEqual(this.pathWslWindowsPathInsideWindows.isHostWindows, false);
+        assert.strictEqual(this.pathWslWindowsPathInsideWindows.isWinePath, false);
+        assert.strictEqual(this.pathWslWindowsPathInsideWindows.isWslMode, true);
+        assert.strictEqual(this.pathWslWindowsPathInsideWindows.asCliPath(), "Z:\\mnt\\c\\devel\\test.mq5");
+        assert.strictEqual(this.pathWslWindowsPathInsideWindows.asTargetPath(), "/mnt/c/devel/test.mq5");
+
+        // C:\\devel\\test.mq5 [WSL(Unix), Windows-style Path, Inside Wine, Through WSL].
+        // Note that in WSL or Unix we can use Windows-host path only in WSL mode (WSL mode will be auto-detected).
+        assert.strictEqual(this.pathWslWindowsPathInsideWine.isValid(), true);
+        assert.strictEqual(this.pathWslWindowsPathInsideWine.isHostWindows, false);
+        assert.strictEqual(this.pathWslWindowsPathInsideWine.isWinePath, true);
+        assert.strictEqual(this.pathWslWindowsPathInsideWine.isWslMode, true);
+        assert.strictEqual(this.pathWslWindowsPathInsideWine.asCliPath(), "C:\\devel\\test.mq5");
+        assert.match(this.pathWslWindowsPathInsideWine.asTargetPath(), /home\/.*?\/\.wine\/dosdevices\/c:\/devel\/test\.mq5/);
+
+        // /home/devel/test.mq5 [Unix, Unix-style Path, Outside Wine, Non-WSL].
+        assert.strictEqual(this.pathUnixHostUnixPath.isValid(), true);
+        assert.strictEqual(this.pathUnixHostUnixPath.isHostWindows, false);
+        assert.strictEqual(this.pathUnixHostUnixPath.isWinePath, false);
+        // WSL mode testing is not necessary.
+        assert.strictEqual(this.pathUnixHostUnixPath.asCliPath(), "/home/devel/test.mq5");
+        assert.strictEqual(this.pathUnixHostUnixPath.asTargetPath(), "/home/devel/test.mq5");
+
+        // C:\\devel\\test.mq5 [Unix, Unix-style Path, Inside Wine, Non-WSL].
+        assert.strictEqual(this.pathUnixHostUnixPathInsideWine.isValid(), true);
+        assert.strictEqual(this.pathUnixHostUnixPathInsideWine.isHostWindows, false);
+        assert.strictEqual(this.pathUnixHostUnixPathInsideWine.isWinePath, true);
+        // WSL mode testing is not necessary.
+        assert.strictEqual(this.pathUnixHostUnixPathInsideWine.asCliPath(), "C:\\devel\\test.mq5");
+        assert.match(this.pathUnixHostUnixPathInsideWine.asTargetPath(), /home\/.*?\/\.wine\/dosdevices\/c:\/devel\/test\.mq5/);
+
+        // C:\\devel\\test.mq5 [Unix, Windows-style Path, Outside Wine, Non-WSL].
+        // Such path is invalid as we can't map Windows path to Unix host outside the Wine or for non-Wine mode.
+        assert.strictEqual(this.pathUnixHostWindowsPathOutsideWine.isValid(), false);
+        assert.strictEqual(this.pathUnixHostWindowsPathOutsideWine.isHostWindows, false);
+        assert.strictEqual(this.pathUnixHostWindowsPathOutsideWine.isWinePath, false);
+        // WSL mode testing is not necessary.
+
+        // @todo Include tests where Windows paths are slashed and Unix paths are backslashed (it should work in both cases).
+
+        // We're done.
+    }
+}
+
+function runTests() {
+    new Tests().runAll();
+
+    console.log(`Testing done.`);
+}
+
+module.exports = {
+    runTests
+};

--- a/src/universalpath.js
+++ b/src/universalpath.js
@@ -13,72 +13,88 @@ const OsType = {
 /**
  * Usage:
  *
- * const path = new UniversalPath('/home/mx/test.mq5', OSTypes.Unix, true);
+ * - Auto-detection:
+ * const path = new UniversalPath('/home/mx/test.mq5');
  *
- * Scenarios:
- *
- * 1. Windows. Not using WSL. Given Windows-host path, e.g., "C:/tmp/test.mq5":
- *
- * asWinePath() = undefined
- * asUnixPath() = undefined
- * asTargetPath() = "C:/tmp/test.mq5"
- * asCliPath() = "C:/tmp/test.mq5"
- *
- * 2. Windows. Using WSL. Given Windows-host path, e.g., "C:/tmp/test.mq5":
- *
- * asWinePath() = "Z:/mnt/c/tmp/test.mq5"
- * asUnixPath() = "/mnt/c/tmp/test.mq5"
- * asTargetPath() = same as asUnixPath()
- * asCliPath() = same as asWinePath()
- *
- * 3. Windows. Using WSL. Given wine path, e.g., "C:/Program Files/MetaTrader 5/MQL5/test.mq5":
- *
- * asWinePath() = "C:/Program Files/MetaTrader 5/MQL5/test.mq5"
- * asUnixPath() = "/home/.../.wine/dosdevices/C:/Program Files/MetaTrader 5/MQL5/test.mq5" (winepath -u "C:/Program Files/MetaTrader 5/MQL5/test.mq5")
- * asTargetPath() = same as asUnixPath()
- * asCliPath() = same as asWinePath()
- *
- * 4. Windows. Using WSL. Given unix path, e.g., "/tmp/test.mq5":
- *
- * asWinePath() = "Z:/tmp/test.mq5"
- * asUnixPath() = "/tmp/test.mq5"
- * asTargetPath() = same as asUnixPath()
- * asCliPath() = same as asWinePath()
- *
- * 5. Unix. Given unix path, e.g., "/tmp/test.mq5":
- *
- * Same as 4.
- *
- * 6. Unix. Given wine path, e.g., "C:/Program Files/MetaTrader 5/MQL5/test.mq5":
- *
- * Same as 3.
- *
+ * - Overriding OS'es, platforms and WSL mode for testing purposes:
+ * const path = new UniversalPath('/home/mx/test.mq5', false, OsType.Unix, OsType.Windows, false);
  */
 class UniversalPath {
-  constructor(path, isWinePath, osType) {
-    if (osType == OsType.Unknown) {
-      // @todo detecting system.
-      if (isWinePath || path.match(/^([a-zA-Z]:(\/|\\)|\\\\)/))
-        osType = OsType.Windows;
-      else
-        if (path.substring(0, 1) == '/')
-          osType = OsType.Unix;
-        else
-          osType = OsType.Unknown;
+  /**
+   * Constructor.
+   */
+  constructor(path, isWinePath, osType, platformOverride, isWslOverride) {
+    if (path.length == 0)
+      osType = OsType.Unknown;
+    else {
+      if (osType == OsType.Unknown)
+        // @todo detecting system.
+        osType = this.detectOs(path, isWinePath);
+
+      if (osType == OsType.Unknown)
+        throw new Error(`Error: Could not detect OS for path "${path}"!`);
     }
 
-    if (osType == OsType.Unknown)
-      throw new Error(`Error: Could not detect OS for path "${path}"!`);
+    this.path = osType == OsType.Windows ? paths.backslashize(path) : paths.slashize(path);
+    this.isWinePath = isWinePath ?? false;
+    this.pathOs = osType ?? OsType.Unknown;
+    this.platformOverride = platformOverride ?? OsType.Unknown;
+    this.isWslOverride = isWslOverride;
+  }
 
-    this.path = path;
-    this.isWinePath = isWinePath;
-    this.pathOs = osType;
+  /**
+   * Tries to detect OS for a given path.
+   */
+  detectOs(path, isWinePath) {
+    if (path.length == 0)
+      return OsType.Unknown;
+
+    let osType;
+
+    if (isWinePath || path.match(paths.reWindowsDriveLetterPath))
+      osType = OsType.Windows;
+    else
+      if (path.substring(0, 1) == '/')
+        osType = OsType.Unix;
+      else
+        osType = OsType.Unknown;
+
+    return osType;
+  }
+
+  /**
+   * Checks whether this object has valid parameters.
+   */
+  isValid() {
+    if (this.path.length == 0)
+      return true;
+
+    if (this.pathOs == OsType.Unknown)
+      return false;
+
+    if (!this.isHostWindows && this.pathOs == OsType.Windows && !this.isWinePath && !this.isWslMode)
+      // On Unix, Windows path is only valid for inside-Wine path or under WSL environment.
+      return false;
+
+    if (this.path.match(paths.reDosDevices) && this.isHostWindows && !this.isWslMode)
+      // This path is invalid. We can't map under-Wine path into path in non-WSL mode on Windows host.
+      return false;
+
+    if (this.path.match(paths.reWindowsDriveLetterPath) && !this.isHostWindows && !this.isWslMode && !this.isWinePath)
+      // Such path is invalid as we can't map Windows path to Unix host outside the Wine or for non-Wine mode.
+      return false;
+
+    return true;
   }
 
   /**
    * Converts current path into Windows one to be used by Windows host or by wine.
    */
   asCliPath() {
+    if (this.path.length == 0)
+      // Empty path.
+      return '';
+
     if (this.pathOs == OsType.Unknown)
       // OS should be auto-detected from path given to constructor.
       throw new Error(`Error: Unsupported path OS type!`);
@@ -90,57 +106,88 @@ class UniversalPath {
     // Host path scenario (path outside the wine):
 
     if (this.pathOs == OsType.Windows) { // pathOs = Windows, isWinePath = false, path = "C:/tmp/test.mq5".
-      if (this.isHostWindows && !this.isWslMode)
-        // On Windows-host environment, non-WSL mode and Windows path we don't need to convert anything. Above path will stay as "C:/tmp/test.mq5".
-        return this.path;
-      else
-        if (this.isHostWindows && this.isWslMode) {
+      if (this.isHostWindows) {
+        if (this.isWslMode)
           // On Windows-host environment, WSL mode and Windows path we will create path via: wsl.exe winepath -w `wslpath -a PATH`.
           return paths.convertWindowsHostToWinePath(this.path);
-        }
-        else // if !this.isHostWindows
-          // On Unix-host environment and Windows path we assume that path in an inside-wine path.
+        else
+          // On Windows-host environment, non-WSL mode and Windows path we don't need to convert anything. Above path will stay as "C:/tmp/test.mq5".
           return this.path;
+      }
+      else { // if !this.isHostWindows
+        // On Unix-host environment, Windows path and non-Wine path we assume that path is a Windows-host path.
+        return paths.convertWindowsHostToWinePath(this.path);
+      }
     }
-    else
+    else {
       if (this.pathOs == OsType.Unix) {
         if (!this.isHostWindows || (this.isHostWindows && this.isWslMode))
           // On Unix-host environment or WSL mode and Unix path we will create path via: [wsl.exe] winepath -w PATH.
           return paths.convertUnixPathToWinePath(this.path);
         else // if this.isHostWindows
-          // We can't create path in Windows-host environment, non WSL mode and Unix path.
-          throw new Error(`Error: Could not convert Windows-host Unix path "${this.path}" to anything considerable. Please provide Windows path or enable WSL mode.`);
+          if (this.path.match(paths.reUnixMntWindowsLetter))
+            // Normally, we can't specify Unix path under Windows with disabled WSL mode.
+            // However, we allow such path, so user could leave it when switching between Windows and WSL if he expects Windows-host path.
+            return paths.convertUnixMntPathToWindowsPath(this.path);
+          else
+            // We can't create path in Windows-host environment, non WSL mode and Unix path.
+            throw new Error(`Error: Could not convert Windows-host Unix path "${this.path}" to anything considerable. Please provide Windows path or enable WSL mode.`);
       }
       else
         // In Windows-host environment we
         throw new Error(`Error: Not implemented: Convert Windows host path into wine path.`);
+    }
   }
 
   /**
    * Converts current path into target system one. E.g., for VS Code hinting system.
    */
   asTargetPath() {
+    if (this.path.length == 0)
+      // Empty path.
+      return '';
+
     if (this.pathOs == OsType.Unknown)
       // OS should be auto-detected from path given to constructor.
       throw new Error(`Error: Unsupported path OS type!`);
 
     if (this.pathOs == OsType.Windows) {
-      if (this.isHostWindows && !this.isWslMode)
-        return this.path;
-      else
-        if (this.isHostWindows && this.isWslMode)
+      if (this.isHostWindows) {
+        if (!this.isWslMode)
+          return this.path;
+
+        if (this.isWslMode && this.isWinePath)
           return paths.convertWineToWindowsPath(this.path);
-        else // if !this.isHostWindows
-          // Having Unix-host and Windows path, we assume that the path is an inside-wine path. We have to convert it via: winepath -u PATH.
+
+        if (this.isWslMode && !this.isWinePath)
+          return paths.backslashize(this.path);
+      }
+      else {
+        if (this.isWinePath)
+          // Converting Windows path into path inside Wine (/home/<user>/.wine/dosdevices/<drive>:/...).
+          return paths.convertWinePathToUnixDosDevicesPath(this.path);
+
+        if (this.isWslMode)
+          // Converting Windows path into path under /mnt/<letter>/.
+          return paths.convertWindowsHostToWslPath(this.path);
+        else // if !this.isWslMode
           return paths.convertWineToUnixPath(this.path);
+      }
     }
     else
       if (this.pathOs == OsType.Unix) {
-        if (this.isHostWindows && !this.isWslMode)
-          throw new Error(`Error: Could not convert Windows-host Unix path "${this.path}" to anything considerable. Please provide Windows path or enable WSL mode.`);
+        if (this.isHostWindows && !this.isWslMode) {
+          if (this.path.match(paths.reUnixMntWindowsLetter))
+            // Normally, we can't specify Unix path under Windows with disabled WSL mode.
+            // However, we allow such path, so user could leave it when switching between Windows and WSL if he expects Windows-host path.
+            return paths.convertUnixMntPathToWindowsPath(this.path);
+          else
+            throw new Error(`Error: Could not convert Windows-host Unix path "${this.path}" to anything considerable. Please provide Windows path or enable WSL mode.`);
+        }
         else
           if (this.isHostWindows && this.isWslMode)
-            return paths.convertWineToWindowsPath(this.path);
+            // Note that when testing we override WSL default distribution name, so tests will check for name "Ubuntu". In WSL or Unix the `wsl -l -q` will be called in order to check distribution name.
+            return paths.convertWineToWindowsPath(this.path, this.isWslOverride == undefined && this.platformOverride == undefined ? undefined : 'Ubuntu');
           else // if !this.isHostWindows
             // Having Unix-host and Unix path, we just return the path as it is.
             return this.path;
@@ -150,10 +197,10 @@ class UniversalPath {
   /**
    * Creates UniversalPath clone with difference file extension.
    */
-  cloneWithExtension(extension) {
+  cloneWithExtension(/*extension*/) {
     const fileInfo = paths.getFileInfo(this.path);
     const newPath = this.path.replace(fileInfo.fileName, fileInfo.fileName.match(/.+(?=\.)/) + '.log');
-    return new UniversalPath(newPath, this.isWinePath, this.pathOs);
+    return new UniversalPath(newPath, this.isWinePath, this.pathOs, this.platformOverride, this.isWslOverride);
   }
 
   /**
@@ -171,6 +218,9 @@ class UniversalPath {
    * Returns true if extension is running on Windows host.
    */
   get isHostWindows() {
+    if (this.platformOverride !== undefined)
+      return this.platformOverride == OsType.Windows;
+
     return process.platform == 'win32';
   }
 
@@ -178,6 +228,9 @@ class UniversalPath {
    * Returns true if target app should be ran through WSL.
    */
   get isWslMode() {
+    if (this.isWslOverride !== undefined)
+      return this.isWslOverride;
+
     return config.current.MTE.PassThroughWSL;
   }
 }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -27,7 +27,7 @@ async function searchFileAndGenerateUri(fileName) {
 async function addFolderToWorkspace(folderPath) {
   const uri = vscode.Uri.file(folderPath);
   const workspaceFolder = { uri, name: uri.fsPath, index: 0 };
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve/*, reject*/) => {
     // Set up the event listener for workspace folder changes
     const disposable = vscode.workspace.onDidChangeWorkspaceFolders(event => {
       disposable.dispose(); // Clean up the listener after the event is handled.


### PR DESCRIPTION
We just need to add WSL auto-detection if user is running VS Code inside WSL's Ubuntu. Is such situation `UniversalPath.isWslMode` would return `true` and _"Pass Through WSL"_ option won't be used.