### PR TITLE
Support for wine and Codespaces paths

### DIFF
--- a/src/commands/CompileCommand.js
+++ b/src/commands/CompileCommand.js
@@ -115,8 +115,14 @@ async function CompileCommand(mode) {
 
         let platformIncludePathBaseFolder = '';
 
-        if (config.platformIncludePath(platformVersion).length > 0 && config.platformIncludePath(platformVersion).endsWith("/Include"))
-          platformIncludePathBaseFolder = config.platformIncludePath(platformVersion).substring(0, config.platformIncludePath(platformVersion).length - 8);
+        if (config.platformIncludePath(platformVersion).length > 0) {
+          let includePath = config.platformIncludePath(platformVersion);
+
+          if (config.platformIncludePath(platformVersion).endsWith("/Include"))
+            includePath = includePath.substring(0, config.platformIncludePath(platformVersion).length - 8);
+
+          platformIncludePathBaseFolder = includePath;
+        }
 
         // We want include path to be Windows-specific.
         platformIncludePathBaseFolder = new UniversalPath(platformIncludePathBaseFolder, config.platformIncludePathIsWinePath(platformVersion)).asCliPath();

--- a/src/debug.js
+++ b/src/debug.js
@@ -2,7 +2,7 @@ const vscode = require('vscode');
 
 module.exports = {
   // You may force debug logging via switching this to true.
-  forceEnable: false,
+  forceEnable: true,
 
   // Whether we want to override extension settings to the ones in "configOverride".
   overrideConfig: false,

--- a/src/paths.js
+++ b/src/paths.js
@@ -191,6 +191,14 @@ function convertUnixPathToWinePath(unixPath) {
     return backslashize(winePath);
   }
 
+  // Check if the path starts with "/workspaces" (codespaces "Z:\workspaces").
+  if (unixPath.startsWith('/workspaces/')) {
+    winePath = 'Z:' + unixPath;
+
+    // Back-slashizing for Windows.
+    return backslashize(winePath);
+  }
+
   return slashize(unixPath);
 }
 


### PR DESCRIPTION
This pull request includes several changes to improve the handling of file paths and debug logging. The most important changes are focused on refining the `CompileCommand` logic, enabling debug logging by default, and adding a new path conversion check.

Improvements to file path handling:

* [`src/commands/CompileCommand.js`](diffhunk://#diff-62f46b45e5b0eb1e65e886ee5eafdb0c86b35393e8799e513d27eda552a4c078L118-R125): Refactored the logic to determine the `platformIncludePathBaseFolder` for better readability and maintainability.
* [`src/paths.js`](diffhunk://#diff-fa8852061c2af471aee4f01ec070f8d1020d0c60646679c31c4af21cb4f5106cR194-R201): Added a new check in the `convertUnixPathToWinePath` function to handle paths starting with "/workspaces" for codespaces.

## Summary by Sourcery

Improves file path handling and enables debug logging by default. Refactors the logic to determine the platform include path base folder for better readability and maintainability. Adds a new check in the convertUnixPathToWinePath function to handle paths starting with "/workspaces" for codespaces.

New Features:
- Enables debug logging by default.

Enhancements:
- Refactors the logic to determine the platform include path base folder for better readability and maintainability.
- Adds a new check in the convertUnixPathToWinePath function to handle paths starting with "/workspaces" for codespaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Revised compilation command logic to improve clarity in determining directory paths.
- **New Features**
	- Now defaults to enhanced diagnostic logging for better troubleshooting.
	- Introduced support for converting workspace paths into a Windows-compatible format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->